### PR TITLE
Move code into Swift package.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,22 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Swift
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v

--- a/GEDCOMConverter.podspec
+++ b/GEDCOMConverter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GEDCOMConverter'
-  s.version          = '0.1.6'
+  s.version          = '0.1.7'
   s.summary          = 'With GEDCOMConverter, parsing a GEDCOM file to native Swift objects is too easy!'
 
 # This description is used to generate tags and improve search results.
@@ -37,7 +37,7 @@ The `GEDCOM` object will automatically generate a `head`, and `individuals`, `fa
 
   s.ios.deployment_target = '9.3'
 
-  s.source_files = 'GEDCOMConverter/Classes/**/*'
+  s.source_files = 'Sources/GEDCOMConverter/Classes/**/*'
   
   # s.resource_bundles = {
   #   'GEDCOMConverter' => ['GEDCOMConverter/Assets/*.png']

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GEDCOMConverter",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "GEDCOMConverter",
+            targets: ["GEDCOMConverter"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "GEDCOMConverter"),
+        .testTarget(
+            name: "GEDCOMConverterTests",
+            dependencies: ["GEDCOMConverter"]),
+    ]
+)

--- a/Sources/GEDCOMConverter/Classes/Extensions.swift
+++ b/Sources/GEDCOMConverter/Classes/Extensions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public func += <K, V> (left: inout [K:V], right: [K:V]) {
+public func += <K, V> (left: inout [K: V], right: [K: V]) {
   for (k, v) in right {
     left[k] = v
   }

--- a/Sources/GEDCOMConverter/Classes/GEDCOM.swift
+++ b/Sources/GEDCOMConverter/Classes/GEDCOM.swift
@@ -6,55 +6,55 @@
 //
 
 import Foundation
-public class GEDCOM:Codable {
-  public var head:Head?
-  public var individuals:[Individual] = []
-  public var families:[Family] = []
-  public var sours:[Sour] = []
-  
-  public init(_ content:String) {
+public class GEDCOM: Codable {
+  public var head: Head?
+  public var individuals: [Individual] = []
+  public var families: [Family] = []
+  public var sours: [Sour] = []
+
+  public init(_ content: String) {
     print("GEDCOM INIT")
-    //break apart content into lines of text
+    // break apart content into lines of text
     let linesAsStrings = content.components(separatedBy: .newlines).filter({$0 != ""})
-    //convert to lines of level(Int),type(String) and data(String)
+    // convert to lines of level(Int),type(String) and data(String)
     let lines = linesAsStrings.compactMap({Line($0)})
     var linesCopy = lines
-    //convert to multi-dimensional arrays/dictionaries of String
+    // convert to multi-dimensional arrays/dictionaries of String
     let data = GedcomParser.getAllData(atOrAbove: 0, from: &linesCopy)
-    //print(data)
-    //parse parts
-    if let headData = data["HEAD"] as? [String:Any] {
+    // print(data)
+    // parse parts
+    if let headData = data["HEAD"] as? [String: Any] {
       self.head = Head(headData)
     }
     let individualLines = data.filter({ $0.key.first! == "I" ||  $0.key.first! == "P" })
     individuals = []
     for line in individualLines {
-      if let individualData = line.value as? [String:Any] {
-        let individual = Individual(individualData,for:line.key)
+      if let individualData = line.value as? [String: Any] {
+        let individual = Individual(individualData, for: line.key)
         individuals.append(individual)
       }
     }
-    //individuals.forEach{print($0)}
+    // individuals.forEach{print($0)}
     let familyLines = data.filter({ $0.key.first! == "F"})
     families = []
     for line in familyLines {
-      if let familyData = line.value as? [String:Any] {
-        families.append(Family(familyData,for:line.key))
+      if let familyData = line.value as? [String: Any] {
+        families.append(Family(familyData, for: line.key))
       }
     }
     let sourLines = data.filter({ $0.key.first! == "S"})
     sours = []
     for line in sourLines {
-      if let sourData = line.value as? [String:Any] {
-        sours.append(Sour(sourData, for:line.key))
+      if let sourData = line.value as? [String: Any] {
+        sours.append(Sour(sourData, for: line.key))
       }
     }
   }
-  
-  public convenience init?(fileName:String) throws {
+
+  public convenience init?(fileName: String) throws {
     print("GEDCOM convenience INIT")
     guard let path = Bundle.main.path(forResource: fileName, ofType: "ged") else {return nil}
-    let content = try String(contentsOfFile:path, encoding: String.Encoding.utf8)
+    let content = try String(contentsOfFile: path, encoding: String.Encoding.utf8)
     self.init(content)
   }
 }

--- a/Sources/GEDCOMConverter/Classes/GedcomParser/GedcomParser.swift
+++ b/Sources/GEDCOMConverter/Classes/GedcomParser/GedcomParser.swift
@@ -7,20 +7,18 @@
 
 import Foundation
 
-
-
 public let q = "?"
 
-//0 @I1@ INDI
+// 0 @I1@ INDI
 public struct Line {
-  public var level:Int
+  public var level: Int
   public var type = ""
   public var data = ""
-  public init?(_ lineText:String) {
-    //level
+  public init?(_ lineText: String) {
+    // level
     guard let level = Int(lineText.prefix(1)) else {return nil}
     self.level = level
-    //type
+    // type
     var dataOffset=3
     let i = lineText.index(lineText.startIndex, offsetBy: 2)
     if lineText[i] == "@" {
@@ -32,12 +30,12 @@ public struct Line {
     } else {
       let indexStartOfType = lineText.index(lineText.startIndex, offsetBy: 2)
       type = String(lineText[indexStartOfType...])
-      if let spaceIndex = type.index(of: " ") {
+      if let spaceIndex = type.firstIndex(of: " ") {
         type = String(type[..<spaceIndex])
       }
       dataOffset = type.count + 3
     }
-    //get data
+    // get data
     if lineText.count > dataOffset {
       let indexStartOfData = lineText.index(lineText.startIndex, offsetBy: dataOffset)
       data = String(lineText[indexStartOfData...])
@@ -54,33 +52,33 @@ public struct Line {
 }
 
 public struct GedcomParser {
-  public static func getAllData(atOrAbove level:Int,
-                                from lines:inout [Line],
-                                with property:[String:Any]? = nil)->[String:Any] {
-    var data:[String:Any] = [:]
+  public static func getAllData(atOrAbove level: Int,
+                                from lines: inout [Line],
+                                with property: [String: Any]? = nil) -> [String: Any] {
+    var data: [String: Any] = [:]
     if let property = property {
       data += property
     }
     while lines.count>0 && lines[0].level == level {
       let line = lines[0]
       lines.removeFirst()
-      
+
       if lines.count>0 && lines[0].level == level + 1 {
-        var dataToSet:[String:Any]
-        //this is a multi-line property
+        var dataToSet: [String: Any]
+        // this is a multi-line property
         if line.data != "" {
-          //the data of the root line contains something
-          dataToSet = getAllData(atOrAbove: level+1, from: &lines, with: ["ROOT":line.data])
+          // the data of the root line contains something
+          dataToSet = getAllData(atOrAbove: level+1, from: &lines, with: ["ROOT": line.data])
         } else {
-          //the data of the root line contains nothing
+          // the data of the root line contains nothing
           dataToSet = getAllData(atOrAbove: level+1, from: &lines)
         }
         setDictionary(data: &data, with: line.type, to: dataToSet)
       } else {
-        //this is a single-line property, set to String
+        // this is a single-line property, set to String
         setDictionary(data: &data, with: line.type, to: line.data)
       }
-      
+
       /*
        //Turn data into array of data if it already exists
        if data[line.type] == nil {
@@ -94,12 +92,12 @@ public struct GedcomParser {
     }
     return data
   }
-  public static func setDictionary<T>(data:inout [String:Any], with property:String, to dataToSet:T) {
-    //Turn data into array of data if it already exists
+  public static func setDictionary<T>(data: inout [String: Any], with property: String, to dataToSet: T) {
+    // Turn data into array of data if it already exists
     if data[property] == nil {
       data[property] = dataToSet
     } else if let oldData = data[property] as? T {
-      var array:[T] = [oldData]
+      var array: [T] = [oldData]
       array.append(dataToSet)
       data[property] = array
     } else if var array = data[property] as? [T] {
@@ -108,4 +106,3 @@ public struct GedcomParser {
     }
   }
 }
-

--- a/Sources/GEDCOMConverter/Classes/GedcomParser/Keyable.swift
+++ b/Sources/GEDCOMConverter/Classes/GedcomParser/Keyable.swift
@@ -7,100 +7,100 @@
 
 import Foundation
 public struct KeyObject {
-  public var keyPath:AnyKeyPath
-  public var gedcomKey:String
+  public var keyPath: AnyKeyPath
+  public var gedcomKey: String
 }
 public protocol Keyable {
-  static var keys:[KeyObject] {get}
-  //var unparsedData:[String:Any] {get set}
+  static var keys: [KeyObject] {get}
+  // var unparsedData:[String:Any] {get set}
 }
 public extension Keyable {
-  public func initKeys(with data:[String:Any]) {
+  func initKeys(with data: [String: Any]) {
     var instance = self
-    var data:[String:Any] = data
+    var data: [String: Any] = data
     for key in Self.keys {
       if let keyPath = key.keyPath as?  WritableKeyPath<Self, String?> {
         let value = data.removeValue(forKey: key.gedcomKey)
         if let value = value as? String {
           instance[keyPath: keyPath] =  value
-        } else if let value = value as? [String:Any], let rootValue = value["ROOT"] as? String {
+        } else if let value = value as? [String: Any], let rootValue = value["ROOT"] as? String {
           instance[keyPath: keyPath] =  rootValue
         } else if let value = value as? [String] {
           instance[keyPath: keyPath] = value[0]
-        } else if let value = value as? [[String:Any]], let rootValue = value.first?["ROOT"] as? String {
+        } else if let value = value as? [[String: Any]], let rootValue = value.first?["ROOT"] as? String {
           instance[keyPath: keyPath] = rootValue
         } else {
           instance[keyPath: keyPath] = nil
         }
       }
-        //HEAD
+        // HEAD
       else if let keyPath = key.keyPath as? WritableKeyPath<Self, Gedc?> {
-        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String:Any] {
-          instance[keyPath:keyPath] = Gedc(internalData)
+        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String: Any] {
+          instance[keyPath: keyPath] = Gedc(internalData)
         }
       } else if let keyPath = key.keyPath as?  WritableKeyPath<Self, Sour?> {
-        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String:Any] {
-          instance[keyPath:keyPath] = Sour(internalData)
+        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String: Any] {
+          instance[keyPath: keyPath] = Sour(internalData)
         }
       }
-        //INDIVIDUAL
+        // INDIVIDUAL
       else if let keyPath = key.keyPath as? WritableKeyPath<Self, Event?> {
         let value = data.removeValue(forKey: key.gedcomKey)
-        if let value = value as? [String:Any] {
-          instance[keyPath:keyPath] = Event(value)
-        } else if let value = value as? [[String:Any]], let internalData = value.first {
-          instance[keyPath:keyPath] = Event(internalData)
+        if let value = value as? [String: Any] {
+          instance[keyPath: keyPath] = Event(value)
+        } else if let value = value as? [[String: Any]], let internalData = value.first {
+          instance[keyPath: keyPath] = Event(internalData)
         }
       } else if let keyPath = key.keyPath as? WritableKeyPath<Self, [Event]> {
         let value = data.removeValue(forKey: key.gedcomKey)
-        if let internalData = value as? [String:Any] {
-          instance[keyPath:keyPath].append(Event(internalData))
-        } else if let internalData = value as? [[String:Any]] {
+        if let internalData = value as? [String: Any] {
+          instance[keyPath: keyPath].append(Event(internalData))
+        } else if let internalData = value as? [[String: Any]] {
           internalData.forEach {
-            instance[keyPath:keyPath].append(Event($0))
+            instance[keyPath: keyPath].append(Event($0))
           }
         }
       } else if let keyPath = key.keyPath as?  WritableKeyPath<Self, PlaceObject?> {
         let value = data.removeValue(forKey: key.gedcomKey)
         if let internalData = value as? String {
-          instance[keyPath:keyPath] = PlaceObject(internalData)
+          instance[keyPath: keyPath] = PlaceObject(internalData)
         }
       } else if let keyPath = key.keyPath as? WritableKeyPath<Self, [Object]> {
         let value = data.removeValue(forKey: key.gedcomKey)
-        if let internalData = value as? [String:Any] {
-          instance[keyPath:keyPath].append(Object(internalData))
-        } else if let internalData = value as? [[String:Any]] {
+        if let internalData = value as? [String: Any] {
+          instance[keyPath: keyPath].append(Object(internalData))
+        } else if let internalData = value as? [[String: Any]] {
           internalData.forEach {
-            instance[keyPath:keyPath].append(Object($0))
+            instance[keyPath: keyPath].append(Object($0))
           }
         }
       }
-        //FAMILY
+        // FAMILY
       else if let keyPath = key.keyPath as?  WritableKeyPath<Self, [Child]> {
         let value = data.removeValue(forKey: key.gedcomKey)
-        if let internalData = value as? [String:Any] {
-          instance[keyPath:keyPath].append(Child(internalData))
-        } else if let internalData = value as? [[String:Any]] {
+        if let internalData = value as? [String: Any] {
+          instance[keyPath: keyPath].append(Child(internalData))
+        } else if let internalData = value as? [[String: Any]] {
           internalData.forEach {
-            instance[keyPath:keyPath].append(Child($0))
+            instance[keyPath: keyPath].append(Child($0))
           }
         }
       }
-        //GENERAL
+        // GENERAL
       else if let keyPath = key.keyPath as?  WritableKeyPath<Self, DateObject?> {
         if let internalData = data.removeValue(forKey: key.gedcomKey) as? String {
-          instance[keyPath:keyPath] = DateObject(internalData)
+          instance[keyPath: keyPath] = DateObject(internalData)
         }
       } else if let keyPath = key.keyPath as? WritableKeyPath<Self, Data?> {
-        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String:Any] {
-          instance[keyPath:keyPath] = Data(internalData)
+        if let internalData = data.removeValue(forKey: key.gedcomKey) as? [String: Any] {
+          instance[keyPath: keyPath] = Data(internalData)
         }
       }
     }
     if data.count>0 {
-      //if var instance = instance as? Keyable {
+      // if var instance = instance as? Keyable {
       //  instance.unparsedData = data
-      //}
+      // }
       print("Unparsed data: \(data) in \(String(describing: type(of: self)))")
     }
   }

--- a/Sources/GEDCOMConverter/Classes/Model/Family/Child.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Family/Child.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-public class Child:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Child: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Child.id, gedcomKey: "ROOT"),
     KeyObject(keyPath: \Child.fatherRelationship, gedcomKey: "_FREL"),
     KeyObject(keyPath: \Child.motherRelationship, gedcomKey: "_MREL")
   ]
-  public var id:String?
-  public var fatherRelationship:String?
-  public var motherRelationship:String?
-  public init(_ data:[String:Any]) {
+  public var id: String?
+  public var fatherRelationship: String?
+  public var motherRelationship: String?
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {

--- a/Sources/GEDCOMConverter/Classes/Model/Family/Family.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Family/Family.swift
@@ -7,24 +7,24 @@
 
 import Foundation
 
-public class Family:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Family: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Family.husband, gedcomKey: "HUSB"),
     KeyObject(keyPath: \Family.wife, gedcomKey: "WIFE"),
     KeyObject(keyPath: \Family.children, gedcomKey: "CHIL"),
     KeyObject(keyPath: \Family.marriage, gedcomKey: "MARR"),
     KeyObject(keyPath: \Family.root, gedcomKey: "ROOT"),
-    KeyObject(keyPath: \Family.divorced, gedcomKey: "DIV"),
+    KeyObject(keyPath: \Family.divorced, gedcomKey: "DIV")
     ]
-  public var id:String?
-  public var husband:String?
-  public var wife:String?
-  public var children:[Child] = []
-  public var marriage:Event?
-  public var divorced:Event?
-  public var root:String?
-  public init(_ data:[String:Any], for id:String) {
+  public var id: String?
+  public var husband: String?
+  public var wife: String?
+  public var children: [Child] = []
+  public var marriage: Event?
+  public var divorced: Event?
+  public var root: String?
+  public init(_ data: [String: Any], for id: String) {
     self.id = id
     self.initKeys(with: data)
   }

--- a/Sources/GEDCOMConverter/Classes/Model/General/Data.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/General/Data.swift
@@ -6,13 +6,13 @@
 //
 
 import Foundation
-public class Data:Keyable,Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Data: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Data.text, gedcomKey: "TEXT")
   ]
-  public var text:String?
-  public init(_ data:[String:Any]) {
+  public var text: String?
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {

--- a/Sources/GEDCOMConverter/Classes/Model/General/DateObject.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/General/DateObject.swift
@@ -6,14 +6,14 @@
 //
 
 import Foundation
-public struct DateObject:Codable, CustomStringConvertible {
-  public var datesDetected:[Date]?
-  public var dateOriginalText:String
-  public init(_ data:String) {
+public struct DateObject: Codable, CustomStringConvertible {
+  public var datesDetected: [Date]?
+  public var dateOriginalText: String
+  public init(_ data: String) {
     self.dateOriginalText = data
     self.datesDetected = data.detectDates
   }
-  public init(_ date:Date) {
+  public init(_ date: Date) {
     let formatter = DateFormatter()
     formatter.dateFormat = "dd-MMM-yyyy"
     self.dateOriginalText =  formatter.string(from: date)
@@ -23,37 +23,37 @@ public struct DateObject:Codable, CustomStringConvertible {
     return "\(dateOriginalText)"
   }
 }
-extension DateObject:Equatable {}
+extension DateObject: Equatable {}
 public func ==(lhs: DateObject, rhs: DateObject) -> Bool {
   let areEqual = lhs.dateOriginalText == rhs.dateOriginalText
   return areEqual
 }
-//https://stackoverflow.com/a/32595941/3220708
+// https://stackoverflow.com/a/32595941/3220708
 public extension String {
   var nsString: NSString { return self as NSString }
   var length: Int { return nsString.length }
   var nsRange: NSRange { return NSRange(location: 0, length: length) }
-  public var detectDates: [Date]? {
+  var detectDates: [Date]? {
     var date = self
-    //If only the year is known, to make a complete date let's assume 30 Jun
+    // If only the year is known, to make a complete date let's assume 30 Jun
     if date.isYear() {
-      //FIX one day: perhaps this and the following assumption should change the status of the date somehow
+      // FIX one day: perhaps this and the following assumption should change the status of the date somehow
       date = "30 Jun " + self
     }
-    //Work around limitation of NSDataDetector that it only deals with years >= 1700
+    // Work around limitation of NSDataDetector that it only deals with years >= 1700
     let characterSets = CharacterSet(charactersIn: " /\\-.:")
     var parts = date.components(separatedBy: characterSets)
     var joinAgain = false
-    //If only the month and year is known, make a complete date and let's assume 15 of the month
+    // If only the month and year is known, make a complete date and let's assume 15 of the month
     if parts.count == 2, parts[0].isMonth(), parts[1].isYear() {
       parts.insert("15", at: 0)
       joinAgain = true
     }
-    var yearInWaiting:Int?
+    var yearInWaiting: Int?
     var monthInLetters = false
-    for (i,part) in parts.enumerated() {
+    for (i, part) in parts.enumerated() {
       if part.isYear() {
-        if let year = Int(part) {   //should always be true
+        if let year = Int(part) {   // should always be true
           yearInWaiting = year
           if year<1700 {
             parts[i] = "2000"
@@ -67,21 +67,21 @@ public extension String {
     if joinAgain {
       date = parts.joined(separator: monthInLetters ? " " : "/")
     }
-    //Do the date detection
-    var returnDates:[Date]? = []
+    // Do the date detection
+    var returnDates: [Date]? = []
     returnDates = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.date.rawValue)
       .matches(in: date, range: date.nsRange)
-      .compactMap{$0.date}
+      .compactMap {$0.date}
     if let returnDatesUnwrapped = returnDates, returnDatesUnwrapped.count == 0, let yearInWaiting = yearInWaiting {
       date = "30 Jun \(yearInWaiting)"
       returnDates = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.date.rawValue)
         .matches(in: date, range: date.nsRange)
-        .compactMap{$0.date}
+        .compactMap {$0.date}
     }
-    
-    //Reinstate year that we discovered earlier
+
+    // Reinstate year that we discovered earlier
     if var returnDates = returnDates {
-      for (i,returnDate) in returnDates.enumerated() {
+      for (i, returnDate) in returnDates.enumerated() {
         if let year = yearInWaiting {
           var components = Calendar.current.dateComponents([.year, .month, .day], from: returnDate)
           components.year = year
@@ -95,12 +95,12 @@ public extension String {
       return nil
     }
   }
-  //returns true if month
-  public func isMonth()->Bool {
+  // returns true if month
+  func isMonth() -> Bool {
     return (self.count >= 3 && self.rangeOfCharacter(from: .letters) != nil)
   }
-  //returns true if year
-  public func isYear()->Bool {
+  // returns true if year
+  func isYear() -> Bool {
     if self.count==4 && !self.contains(" "), let dateAsInt = Int(self), String(dateAsInt) == self {
       return true
     }
@@ -109,8 +109,7 @@ public extension String {
 }
 
 public extension Collection where Iterator.Element == String {
-  public var dates: [Date] {
-    return compactMap{$0.detectDates}.flatMap{$0}
+  var dates: [Date] {
+    return compactMap {$0.detectDates}.flatMap {$0}
   }
 }
-

--- a/Sources/GEDCOMConverter/Classes/Model/General/Sour.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/General/Sour.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-public class Sour:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Sour: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Sour.name, gedcomKey: "NAME"),
     KeyObject(keyPath: \Sour.version, gedcomKey: "VERS"),
@@ -24,32 +24,32 @@ public class Sour:Keyable, Codable, CustomStringConvertible {
     KeyObject(keyPath: \Sour.root, gedcomKey: "ROOT"),
     KeyObject(keyPath: \Sour.auth, gedcomKey: "AUTH"),
     KeyObject(keyPath: \Sour.publ, gedcomKey: "PUBL"),
-    KeyObject(keyPath: \Sour.repo, gedcomKey: "REPO"),
+    KeyObject(keyPath: \Sour.repo, gedcomKey: "REPO")
     ]
-  public var root:String?
-  public var name:String?
-  public var version:String?
-  public var corp:String?
-  public var api:String?
-  public var data:Data?
-  public var page:String?
-  public var note:String?
-  public var apid:String?
-  public var object:Object?
-  public var title:String?
-  public var file:String?
-  public var form:String?
-  public var auth:String?
-  public var publ:String?
-  public var repo:String?
-  //for non - 0 based SOUR eg.
-  //1 SOUR @S-2126195860@
-  public init(_ data:[String:Any]) {
+  public var root: String?
+  public var name: String?
+  public var version: String?
+  public var corp: String?
+  public var api: String?
+  public var data: Data?
+  public var page: String?
+  public var note: String?
+  public var apid: String?
+  public var object: Object?
+  public var title: String?
+  public var file: String?
+  public var form: String?
+  public var auth: String?
+  public var publ: String?
+  public var repo: String?
+  // for non - 0 based SOUR eg.
+  // 1 SOUR @S-2126195860@
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
-  //for 0 based SOUR eg.
-  //0 @S205747489@ SOUR
-  public init(_ data:[String:Any], for id:String) {
+  // for 0 based SOUR eg.
+  // 0 @S205747489@ SOUR
+  public init(_ data: [String: Any], for id: String) {
     self.root = id
     var data = data
     data.removeValue(forKey: "ROOT")
@@ -59,4 +59,3 @@ public class Sour:Keyable, Codable, CustomStringConvertible {
     return ("Sour:   Name: \(name ?? q), version: \(version ?? q)")
   }
 }
-

--- a/Sources/GEDCOMConverter/Classes/Model/Head/Gedc.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Head/Gedc.swift
@@ -6,19 +6,18 @@
 //
 
 import Foundation
-public class Gedc:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Gedc: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Gedc.version, gedcomKey: "VERS"),
     KeyObject(keyPath: \Gedc.form, gedcomKey: "FORM")
   ]
-  public var version:String?
-  public var form:String?
-  public init(_ data:[String:Any]) {
+  public var version: String?
+  public var form: String?
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {
     return ("GEDC:   Version: \(version ?? q), Form: \(form ?? q)")
   }
 }
-

--- a/Sources/GEDCOMConverter/Classes/Model/Head/Head.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Head/Head.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-public class Head:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Head: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Head.sour, gedcomKey: "SOUR"),
     KeyObject(keyPath: \Head.date, gedcomKey: "DATE"),
@@ -15,16 +15,15 @@ public class Head:Keyable, Codable, CustomStringConvertible {
     KeyObject(keyPath: \Head.char, gedcomKey: "CHAR"),
     KeyObject(keyPath: \Head.submitter, gedcomKey: "SUBM")
   ]
-  public var sour:Sour?
-  public var date:DateObject?
-  public var gedc:Gedc?
-  public var char:String?
-  public var submitter:String?
-  public init(_ data:[String:Any]) {
+  public var sour: Sour?
+  public var date: DateObject?
+  public var gedc: Gedc?
+  public var char: String?
+  public var submitter: String?
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {
     return ("Head: sour: \(sour?.description ?? q), Date: \(date?.description ?? q), Gedc: \(gedc?.description ?? q), Char: \(char ?? q), Submitter: \(submitter ?? q)")
   }
 }
-

--- a/Sources/GEDCOMConverter/Classes/Model/Individual/Event.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Individual/Event.swift
@@ -6,37 +6,37 @@
 //
 
 import Foundation
-public class Event:Keyable, Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Event: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Event.date, gedcomKey: "DATE"),
     KeyObject(keyPath: \Event.place, gedcomKey: "PLAC"),
     KeyObject(keyPath: \Event.type, gedcomKey: "TYPE"),
     KeyObject(keyPath: \Event.sour, gedcomKey: "SOUR"),
     KeyObject(keyPath: \Event.sour, gedcomKey: "OBJE"),
-    KeyObject(keyPath: \Event.root, gedcomKey: "ROOT"),
+    KeyObject(keyPath: \Event.root, gedcomKey: "ROOT")
     ]
-  public var date:DateObject?
-  public var place:PlaceObject?
-  public var type:String?
-  public var sour:Sour?
-  public var object:Object?
-  public var root:String?
+  public var date: DateObject?
+  public var place: PlaceObject?
+  public var type: String?
+  public var sour: Sour?
+  public var object: Object?
+  public var root: String?
   public init() {}
-  public init(_ data:[String:Any]) {
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {
     let q = "?"
     return ("Event: (Date: \( date?.description ?? q ), place:\(place?.description ?? q))")
-    //return ("(Date: \( date != nil ? date!.description : q ), place:\(place != nil ? place!.description : q))")
+    // return ("(Date: \( date != nil ? date!.description : q ), place:\(place != nil ? place!.description : q))")
   }
 }
-extension Event:Equatable {}
+extension Event: Equatable {}
 public func ==(lhs: Event, rhs: Event) -> Bool {
   let areEqual = lhs.type == rhs.type &&
     lhs.place == rhs.place &&
     lhs.date == rhs.date
-  
+
   return areEqual
 }

--- a/Sources/GEDCOMConverter/Classes/Model/Individual/Individual.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Individual/Individual.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-public class Individual:Keyable,Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Individual: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Individual.name, gedcomKey: "NAME"),
     KeyObject(keyPath: \Individual.sex, gedcomKey: "SEX"),
@@ -34,31 +34,31 @@ public class Individual:Keyable,Codable, CustomStringConvertible {
     KeyObject(keyPath: \Individual.root, gedcomKey: "ROOT"),
     KeyObject(keyPath: \Individual.emigration, gedcomKey: "EMIG")
   ]
-  public var id:String?
-  public var name:String?
-  public var sex:String?
-  public var birthday:Event?
-  public var death:Event?
-  public var fams:String?    //spouse family
-  public var famc:String?    //child of family
-  public var rin:String?
-  public var occu:String?
-  public var note:String?
-  public var object:[Object] = []
-  public var residence:[Event] = []
-  public var event:[Event] = []
-  public var married:Event?
-  public var sour:Sour?
-  public var burial:Event?
-  public var christening:Event?
-  public var cremated:Event?
-  public var baptism:Event?
-  public var destination:Event?
-  public var mdcl:String?
-  public var immigration:Event?
-  public var emigration:Event?
-  public var root:String?
-  public init(_ data:[String:Any], for id:String) {
+  public var id: String?
+  public var name: String?
+  public var sex: String?
+  public var birthday: Event?
+  public var death: Event?
+  public var fams: String?    // spouse family
+  public var famc: String?    // child of family
+  public var rin: String?
+  public var occu: String?
+  public var note: String?
+  public var object: [Object] = []
+  public var residence: [Event] = []
+  public var event: [Event] = []
+  public var married: Event?
+  public var sour: Sour?
+  public var burial: Event?
+  public var christening: Event?
+  public var cremated: Event?
+  public var baptism: Event?
+  public var destination: Event?
+  public var mdcl: String?
+  public var immigration: Event?
+  public var emigration: Event?
+  public var root: String?
+  public init(_ data: [String: Any], for id: String) {
     self.id = id
     if id == "P1574" {
       print("STOP HERE")

--- a/Sources/GEDCOMConverter/Classes/Model/Individual/Object.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Individual/Object.swift
@@ -6,17 +6,17 @@
 //
 
 import Foundation
-public class Object:Keyable,Codable, CustomStringConvertible {
-  //public var unparsedData:[String:Any] = [:]
+public class Object: Keyable, Codable, CustomStringConvertible {
+  // public var unparsedData:[String:Any] = [:]
   public static let keys = [
     KeyObject(keyPath: \Object.file, gedcomKey: "FILE"),
     KeyObject(keyPath: \Object.form, gedcomKey: "FORM"),
     KeyObject(keyPath: \Object.title, gedcomKey: "TITL")
   ]
-  public var file:String?
-  public var form:String?
-  public var title:String?
-  public init(_ data:[String:Any]) {
+  public var file: String?
+  public var form: String?
+  public var title: String?
+  public init(_ data: [String: Any]) {
     self.initKeys(with: data)
   }
   public var description: String {
@@ -29,7 +29,7 @@ public class Object:Keyable,Codable, CustomStringConvertible {
      //https://mediasvc.ancestry.com/v2/image/namespaces/1093/media/1e1d842f-8619-4569-b320-f745ace26f19.jpg?client=Trees&imageQuality=hq
      //See: https://support.ancestry.com/s/question/0D515000021Ob3rCAC/getting-images-via-ancestrycom-gedcom-files
   **/
-  public var url:URL? {
+  public var url: URL? {
     guard let file = file,
       let fileUrlComponents = URLComponents(string: file),
       let fileQueryItems = fileUrlComponents.queryItems,

--- a/Sources/GEDCOMConverter/Classes/Model/Individual/PlaceObject.swift
+++ b/Sources/GEDCOMConverter/Classes/Model/Individual/PlaceObject.swift
@@ -6,16 +6,16 @@
 //
 
 import Foundation
-public struct PlaceObject:Codable, CustomStringConvertible {
-  public var place:String
-  public init(_ data:String) {
+public struct PlaceObject: Codable, CustomStringConvertible {
+  public var place: String
+  public init(_ data: String) {
     self.place = data
   }
   public var description: String {
     return ("PlaceObject:   place: \(place)")
   }
 }
-extension PlaceObject:Equatable {}
+extension PlaceObject: Equatable {}
 public func ==(lhs: PlaceObject, rhs: PlaceObject) -> Bool {
   let areEqual = lhs.place == rhs.place
   return areEqual

--- a/Tests/GEDCOMConverterTests/GEDCOMConverterTests.swift
+++ b/Tests/GEDCOMConverterTests/GEDCOMConverterTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import GEDCOMConverter
+
+final class GEDCOMConverterTests: XCTestCase {
+    func testExample() throws {
+        // XCTest Documentation
+        // https://developer.apple.com/documentation/xctest
+
+        // Defining Test Cases and Test Methods
+        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    }
+}


### PR DESCRIPTION
This PR adds SPM support and a couple of other changes:

1. Add Swift package manifest.
2. Move code into `/Sources/` to match SPM convention.
3. Update the podfile to locate the updated code.

Additionally: 

4. Bump the pod version from `0.1.6` to `0.1.7`.
5. Run `swiftlint --fix` on the `/Sources` directory.
6. Resolve deprecations.
    a. Replace `index(of:)` with `firstIndex(of:)`
    b. Remove redundant `public` identifiers.

I tested it by running `swift build`. I did not test if Cocoapods works.

<img width="561" alt="Screenshot 2024-07-04 at 11 55 13 AM" src="https://github.com/craiggrummitt/GEDCOMConverter/assets/427452/3b476aca-3358-45ee-a9c2-60316269f9e6">
